### PR TITLE
Implement /ban command

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -302,16 +302,59 @@ client.once("ready", () => {
         });
       }
     } else if (interaction.commandName === "bannode") {
-      // Get the nodeid argument.
-      const nodeId = interaction.options.getString("nodeid");
+      const roles = await fetchUserRoles(guild, interaction.user.id);
+      if (roles && (roles.includes("Moderator") || roles.includes("Admin"))) {
+        let nodeId = fetchNodeId(interaction);
 
-      // add node to the banned list
+        if (!nodeId) {
+          logger.warn("Received /bannode command with no nodeid");
+          await interaction.reply({
+            content: "Please provide a nodeid",
+            ephemeral: true,
+          });
+          return;
+        }
 
-      // Respond to the command to acknowledge receipt (ephemeral response).
-      await interaction.reply({
-        content: "Ban Command received!",
-        flags: MessageFlags.Ephemeral,
-      });
+        await meshRedis.addBannedNode(nodeId);
+
+        await interaction.reply({
+          content: "Node banned.",
+          flags: MessageFlags.Ephemeral,
+        });
+      } else {
+        await interaction.reply({
+          content: "You do not have permission to use this command",
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+    } else if (interaction.commandName === "unbannode") {
+      const roles = await fetchUserRoles(guild, interaction.user.id);
+      if (roles && (roles.includes("Moderator") || roles.includes("Admin"))) {
+        let nodeId = fetchNodeId(interaction);
+
+        if (!nodeId) {
+          logger.warn("Received /unbannode command with no nodeid");
+          await interaction.reply({
+            content: "Please provide a nodeid",
+            ephemeral: true,
+          });
+          return;
+        }
+
+        await meshRedis.removeBannedNode(nodeId);
+
+        await interaction.reply({
+          content: "Node unbanned.",
+          flags: MessageFlags.Ephemeral,
+        });
+      } else {
+        await interaction.reply({
+          content: "You do not have permission to use this command",
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
     }
   });
 

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -74,23 +74,30 @@ const commands = [
       },
     ],
   },
-  // {
-  //   name: "mynodes",
-  //   description: "List your linked nodes",
-  //   options: [],
-  // },
-  // {
-  //   name: "bannode",
-  //   description: "Ban a node from logger",
-  //   options: [
-  //     {
-  //       name: "nodeid",
-  //       type: ApplicationCommandOptionType.String,
-  //       description: "The node ID to ban",
-  //       required: true,
-  //     },
-  //   ],
-  // },
+  {
+    name: "bannode",
+    description: "Ban a node from logger",
+    options: [
+      {
+        name: "nodeid",
+        type: ApplicationCommandOptionType.String,
+        description: "The node ID to ban",
+        required: true,
+      },
+    ],
+  },
+  {
+    name: "unbannode",
+    description: "Unban a node from logger",
+    options: [
+      {
+        name: "nodeid",
+        type: ApplicationCommandOptionType.String,
+        description: "The node ID to unban",
+        required: true,
+      },
+    ],
+  },
 ];
 
 export default commands;

--- a/src/MeshRedis.ts
+++ b/src/MeshRedis.ts
@@ -268,6 +268,64 @@ class MeshRedis {
     }
     return null;
   }
+
+  async addBannedNode(hexNodeId: string) {
+    try {
+      if (!hexNodeId || hexNodeId.length != "dd0b9347".length) {
+        return "Invalid Node Id";
+      }
+      const bannedNode = await this.redisClient.get(
+        `baymesh:banned:${hexNodeId}`,
+      );
+      if (bannedNode) {
+        logger.info(`Node ${hexNodeId} is already banned`);
+        return `Node ${hexNodeId} is already banned`;
+      }
+      await this.redisClient.set(`baymesh:banned:${hexNodeId}`, "1");
+      return `Node ${hexNodeId} banned`;
+    } catch (err) {
+      logger.error(err.message);
+      return "Error";
+    }
+  }
+
+  async removeBannedNode(hexNodeId: string) {
+    try {
+      if (!hexNodeId || hexNodeId.length != "dd0b9347".length) {
+        return "Invalid Node Id";
+      }
+      const bannedNode = await this.redisClient.get(
+        `baymesh:banned:${hexNodeId}`,
+      );
+      if (!bannedNode) {
+        logger.info(`Node ${hexNodeId} is not banned`);
+        return `Node ${hexNodeId} is not banned`;
+      }
+      await this.redisClient.del(`baymesh:banned:${hexNodeId}`);
+      return `Node ${hexNodeId} unbanned`;
+    } catch (err) {
+      logger.error(err.message);
+      return "Error";
+    }
+  }
+
+  async isBannedNode(hexNodeId: string) {
+    try {
+      if (!hexNodeId || hexNodeId.length != "dd0b9347".length) {
+        return false;
+      }
+      const bannedNode = await this.redisClient.get(
+        `baymesh:banned:${hexNodeId}`,
+      );
+      if (bannedNode) {
+        return true;
+      }
+      return false;
+    } catch (err) {
+      logger.error(err.message);
+      return false;
+    }
+  }
 }
 
 const meshRedis = new MeshRedis();

--- a/src/MessageUtils.ts
+++ b/src/MessageUtils.ts
@@ -30,6 +30,13 @@ const processTextMessage = async (packetGroup, client, guild, discordMessageIdCa
 
   const nodeId = nodeId2hex(packet.from);
 
+  // Check if the node is banned
+  const isBannedNode = await meshRedis.isBannedNode(nodeId);
+  if (isBannedNode) {
+    logger.info(`Node ${nodeId} is banned. Ignoring message.`);
+    return;
+  }
+
   const balloonNode = await meshRedis.isBalloonNode(nodeId);
 
   const content = await createDiscordMessage(packetGroup, text, balloonNode, client, guild);


### PR DESCRIPTION
Fixes #18

Implement the `/ban` and `/unban` commands to allow only admins or mods to ban or unban nodes, and filter out messages and positions from banned nodes.

* **Commands**: Add `/bannode` and `/unbannode` commands with `nodeid` argument in `src/Commands.ts`.
* **Role Checks**: Add role checks for `/bannode` and `/unbannode` commands in `index.ts` to ensure only admins or mods can execute these commands.
* **Ban/Unban Functionality**: Implement functionality to add and remove banned nodes in `index.ts` using `meshRedis.addBannedNode` and `meshRedis.removeBannedNode` methods.
* **Message Filtering**: Filter out messages and positions from banned nodes in `src/MessageUtils.ts` by checking if the node is banned using `meshRedis.isBannedNode`.
* **Redis Methods**: Add `addBannedNode`, `removeBannedNode`, and `isBannedNode` methods in `src/MeshRedis.ts` to manage the banned nodes list in Redis.

